### PR TITLE
remove dev channel-only commands

### DIFF
--- a/Main.php
+++ b/Main.php
@@ -36,7 +36,7 @@ $discord->on('ready', function (Discord $discord) use ($commands) {
 		
 		echo "(".date("d/m h:i:sA").") [#{$message->channel->name}] {$message->author->username}: {$message->content}\n";
 		
-		if (@$message->content[0] == "!" && @$message->content[1] != " " && !$message->author->bot && strlen(@$message->content) >= 2 && $message->channel->id == 274828566909157377) { 
+		if (@$message->content[0] == "!" && @$message->content[1] != " " && !$message->author->bot && strlen(@$message->content) >= 2) { 
 			$commands->funcExec($message);
 		}
 		


### PR DESCRIPTION
Allow bot to take commands from all channels, not just dev channel (LOL).