### PR TITLE
Fix stats and team assignment in DOTA embed

### DIFF
--- a/Commands/Utils.php
+++ b/Commands/Utils.php
@@ -253,7 +253,7 @@
 						$details[$i]['new'] = true;
 						$details[$i]['discord'] = $ids[$i][0];
 						$details[$i]['name'] = $ids[$i][2];
-						$details[$i]['team'] = ($response[0]->player_slot <= 127) ? "Radiant" : "Dire";
+						$team = ($response[0]->player_slot <= 127) ? "Radiant" : "Dire";
 						$details[$i]['win'] = ($response[0]->radiant_win == true && $details[$i]['team'] == "Radiant" || $response[0]->radiant_win == false && $details[$i]['team'] == "Dire") ? "Won" : "Lost";
 						$details[$i]['hero'] = Commands::DOTA_HEROES[$response[0]->hero_id];
 						$details[$i]['stats'] = array("Kills" => $response[0]->kills, "Deaths" => $response[0]->deaths, "Assists" => $response[0]->assists,"HeroDMG" => $response[0]->hero_damage, "TowerDMG" => $response[0]->tower_damage, "XPM" => $response[0]->xp_per_min, "GPM" => $response[0]->gold_per_min);
@@ -286,7 +286,7 @@
 				
 				$embed->addFieldValues("Start Time", $tz->format('g:i A'), true);
 				$embed->addFieldValues("Length", $length, true);
-				$embed->addFieldValues("Game Mode", "{$ranked} {$mode}", true);
+				$embed->addFieldValues("Game Mode", "{$ranked} {$mode} ({$team})", true);
 				
 				$desc = "";
 				
@@ -294,9 +294,9 @@
 					if (@$details[$x]['new']) {
 						$id = $x;
 						$desc .= "<@{$details[$x]['discord']}> **{$details[$x]['win']}** playing as **{$details[$x]['hero']}**";
-						$embed->addFieldValues($details[$x]['name'], "{$details[$x]['hero']}\n{$details[$x]['stats']['Kills']} / {$details[$x]['stats']['Deaths']} / {$details[$x]['stats']['Assists']}\n{$details[$x]['team']}", true);
-						$embed->addFieldValues("Damage", "{$details[$x]['HeroDMG']} hero\n{$details[$x]['stats']['TowerDMG']} tower", true);
-						$embed->addFieldValues("Stats", "{$details[$x]['XPM']} xpm (Lvl ".getLevel(($details[$x]['XPM'] * ($duration / 60))).")\n{$details[$x]['stats']['GPM']} gpm", true);
+						$embed->addFieldValues($details[$x]['name'], "{$details[$x]['hero']}\n{$details[$x]['stats']['Kills']} / {$details[$x]['stats']['Deaths']} / {$details[$x]['stats']['Assists']}", true);
+						$embed->addFieldValues("Damage", "{$details[$x]['stats']['HeroDMG']} hero\n{$details[$x]['stats']['TowerDMG']} tower", true);
+						$embed->addFieldValues("Stats", "{$details[$x]['stats']['XPM']} xpm (Lvl ".getLevel(($details[$x]['stats']['XPM'] * ($duration / 60))).")\n{$details[$x]['stats']['GPM']} gpm", true);
 					}
 				}
 


### PR DESCRIPTION
Corrects the assignment of the team variable and fixes references to player stats in the embed fields, ensuring accurate display of hero damage, tower damage, XPM, and GPM. Also updates the game mode field to include the team.