### PR TITLE
Remove CES news tracker

### DIFF
--- a/Main.php
+++ b/Main.php
@@ -36,8 +36,6 @@
 		
 		$services->updateActivity("Starting up...");
 		$services->checkDatabase();
-		$utils->checkNews();
-		$utils->checkDota();
 
 		$discord->getLoop()->addPeriodicTimer(15, function () use ($services, $utils) {
 			$utils->checkReminders();
@@ -46,7 +44,6 @@
 		
 		$discord->getLoop()->addPeriodicTimer(180, function () use ($utils) {
 			$utils->checkDota();
-			$utils->checkNews();
 		});
 		
 		$discord->getLoop()->addPeriodicTimer(300, function () use ($utils) {


### PR DESCRIPTION
CES is over for 2026 so no longer post news into the server. Also removed start up checks for Dota to stop increased API calls if the bot loops.