### PR TITLE
Allow getMapImg to accept string for place parameter

### DIFF
--- a/Utils/BotUtils.php
+++ b/Utils/BotUtils.php
@@ -165,7 +165,7 @@
 
 		}
 		
-		public function getMapImg(array $place, bool $eq = false, string $name = ''): void {
+		public function getMapImg(array|string $place, bool $eq = false, string $name = ''): void {
 		
 			if ($eq) {
 				if (!file_exists("/Media/Maps/{$name}.png")) { 


### PR DESCRIPTION
Updated the getMapImg method to accept either an array or a string for the $place parameter, increasing its flexibility for different input types.