### PR TITLE
Remove unused parameter from simpleEmbed calls

### DIFF
--- a/Commands/AI.php
+++ b/Commands/AI.php
@@ -73,12 +73,12 @@
 			
 			if (@$response->error->message || @$response->blockReason) { 
 				$reason = ($response->error->message) ? $response->error->message : $response->blockReason;
-				$this->utils->simpleEmbed("Gemini AI", "attachment://gemini.png", "Gemini API Error: *{$reason}*", $message, true, null);
+				$this->utils->simpleEmbed("Gemini AI", "attachment://gemini.png", "Gemini API Error: *{$reason}*", $message, true);
 				return;
 			}
 			
 			if (@$response->candidates[0]->finishReason == "MAX_TOKENS") {
-				$this->utils->simpleEmbed("Gemini AI", "attachment://gemini.png", "Maximum token limit hit for this request. Try something simpler.", $message, true, null);
+				$this->utils->simpleEmbed("Gemini AI", "attachment://gemini.png", "Maximum token limit hit for this request. Try something simpler.", $message, true);
 				return;
 			}
 

--- a/Commands/Reminder.php
+++ b/Commands/Reminder.php
@@ -21,14 +21,14 @@
 			$args2 = explode(" ", $args);
 		
 			if (empty($args) || !is_numeric(intval($args2[0])) || intval($args2[0]) < 1 || !preg_match('/(min(?:ute)?|hour|day|week|month)s?/',$args2[1])) {
-				$this->utils->simpleEmbed("Chat Reminders", "attachment://bot.webp", "Invalid syntax used. Try *!remindme 5 mins/hours/days [message]*", $message, true, null); 
+				$this->utils->simpleEmbed("Chat Reminders", "attachment://bot.webp", "Invalid syntax used. Try *!remindme 5 mins/hours/days [message]*", $message, true); 
 				return;
 			}
 
 			$time = time() + (intval($args2[0]) * intval(preg_replace(array('/min(?:ute)?s?/', '/hours?/', '/days?/', '/weeks?/', '/months?/'), array('60', '3600', '86400', '604800', '2592000'), $args2[1])));
 			
 			if ($time > (time() + 2592000*12)) { 
-				$this->utils->simpleEmbed("Chat Reminders", "attachment://bot.webp", "The time period provided is too far into the future. Limit it to under a year.", $message, true, null); 	
+				$this->utils->simpleEmbed("Chat Reminders", "attachment://bot.webp", "The time period provided is too far into the future. Limit it to under a year.", $message, true); 	
 				return;
 			}
 			
@@ -37,7 +37,7 @@
 			$reminderCount = $checkStmt->fetchColumn();
 			
 			if ($reminderCount > 4) {
-				$this->utils->simpleEmbed("Chat Reminders", "attachment://bot.webp", "Cannot set a new reminder for you as you already have 5 set.", $message, true, null); 
+				$this->utils->simpleEmbed("Chat Reminders", "attachment://bot.webp", "Cannot set a new reminder for you as you already have 5 set.", $message, true); 
 				return;
 			}
 			

--- a/Commands/ReminderList.php
+++ b/Commands/ReminderList.php
@@ -61,7 +61,7 @@
 				});
 			} 
 			else {
-				$this->utils->simpleEmbed("Chat Reminders", "attachment://bot.webp", "You currently have no reminders set. To set one use the command *!remindme 5 mins/hours/days [message]*", $message, true, null); 
+				$this->utils->simpleEmbed("Chat Reminders", "attachment://bot.webp", "You currently have no reminders set. To set one use the command *!remindme 5 mins/hours/days [message]*", $message, true); 
 			}
 		
 		}

--- a/Commands/SinBin.php
+++ b/Commands/SinBin.php
@@ -22,7 +22,7 @@
 			if ($this->utils->isAdmin($message->author->id)) {
 			
 				if (empty($args) || !preg_match("/<@(\d{18})>(?:\s*(\d{1,2})?\s*(.+)?)?/", $args, $matches)) { 
-					$this->utils->simpleEmbed("Sin Bin", "attachment://bot.webp", "Invalid syntax used. Try *!sinbin @username [minutes] [reason]*", $message, true, null);
+					$this->utils->simpleEmbed("Sin Bin", "attachment://bot.webp", "Invalid syntax used. Try *!sinbin @username [minutes] [reason]*", $message, true);
 					return;
 				}
 				
@@ -30,12 +30,12 @@
 				$guild = $this->discord->guilds->get('id', '232691831090053120');
 				$mem = $guild->members->get('id', strval($id));
 				if ($this->utils->isAdmin($mem->id)) { 
-					$this->utils->simpleEmbed("Sin Bin", "attachment://bot.webp", "That user cannot be silenced as they are more powerful than you can ever imagine.", $message, true, null); 
+					$this->utils->simpleEmbed("Sin Bin", "attachment://bot.webp", "That user cannot be silenced as they are more powerful than you can ever imagine.", $message, true); 
 					return;
 				}
 				$time = (is_numeric(@$matches[2])) ? @$matches[2] : 2;
 				$reason = (empty($matches[3])) ? "no reason given." : trim(@$matches[3]);
-				$this->utils->simpleEmbed("Sin Bin", "attachment://bot.webp", "<@{$id}> has been given a **{$time}** minute timeout: ***{$reason}***", $message, false, null);
+				$this->utils->simpleEmbed("Sin Bin", "attachment://bot.webp", "<@{$id}> has been given a **{$time}** minute timeout: ***{$reason}***", $message, false);
 				$mem->timeoutMember(new Carbon("{$time} minutes"));	
 				
 			}

--- a/Commands/StableDiffusion.php
+++ b/Commands/StableDiffusion.php
@@ -49,7 +49,10 @@
 			$browser->post($url, $headers, $postDataEnc)->then(
 				function (ResponseInterface $response) use ($message) {
 					$responseData = json_decode($response->getBody());
-					if (!isset($responseData->predictions[0]->bytesBase64Encoded)) { return $this->utils->simpleEmbed("Imagen AI", "attachment://gemini.png", "No image could be generated.", $message, true, null); }
+					if (!isset($responseData->predictions[0]->bytesBase64Encoded)) { 
+						$this->utils->simpleEmbed("Imagen AI", "attachment://gemini.png", "No image could be generated.", $message, true);
+						return;
+					}
 					$base64 = $responseData->predictions[0]->bytesBase64Encoded;
 					$mimeType = $responseData->predictions[0]->mimeType;
 					$bin = base64_decode($base64);

--- a/Utils/BotUtils.php
+++ b/Utils/BotUtils.php
@@ -274,7 +274,7 @@
 					$guild = $this->discord->guilds->get('id', '232691831090053120');
 					$channel = $guild->channels->get('id', $row['channelid']);
 					$channel->messages->fetch($row['messageid'])->then(function ($message) use ($row) {
-						$this->simpleEmbed("Chat Reminders", "attachment://bot.webp", "<@{$row['userid']}> Here is your reminder: https://discord.com/channels/232691831090053120/{$row['channelid']}/{$row['messageid']}", $message, true, null); 
+						$this->simpleEmbed("Chat Reminders", "attachment://bot.webp", "<@{$row['userid']}> Here is your reminder: https://discord.com/channels/232691831090053120/{$row['channelid']}/{$row['messageid']}", $message, true); 
 					});
 					$deleteStmt->execute([':time' => $row['time']]);
 				


### PR DESCRIPTION
Eliminates the redundant 'null' parameter from calls to utils->simpleEmbed across multiple command files and BotUtils.php. This streamlines the function usage and improves code clarity.