### PR TITLE
Adjust Dota game check timing and active hours

### DIFF
--- a/Main.php
+++ b/Main.php
@@ -52,7 +52,7 @@
 			$services->updateActivity();
 		});
 		
-		$discord->getLoop()->addPeriodicTimer(120, function () use ($dota) {
+		$discord->getLoop()->addPeriodicTimer(180, function () use ($dota) {
 			$dota->checkGames();
 		});
 		

--- a/Utils/Dota.php
+++ b/Utils/Dota.php
@@ -42,7 +42,7 @@
 			$date = new DateTime('now');
 			$current_hour = (int)$date->format('G');
 			
-			if ($current_hour >= 10 || $current_hour <= 2) {
+			if ($current_hour >= 8 || $current_hour <= 1) {
 				
 				$client = new Browser($this->discord->getLoop());
 				


### PR DESCRIPTION
Increased the periodic timer for Dota game checks from 120 to 180 seconds and expanded the active hours to 8 AM–1 AM. These changes help optimize resource usage and better align with user activity patterns.